### PR TITLE
Adding support for quoted strings to be handled as a single field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
+## 0.0.3
+ - Adding support for quoted strings via the `text_qualifier` attribute
+
 ## 0.0.2
  - rescue if the field val has a { but isn't json.  its kind of a crappy test
 
 ## 0.0.1
  - initial create
-

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,9 +3,10 @@ reports, or in general have helped this logstash plugin along its way.
 
 Contributors:
 * Patrick Christopher (coffeepac)
+* Adam Phillabaum (@adamb0mb)
 
 Note: If you've sent us patches, bug reports, or otherwise contributed to
-this Logstash plugin, and you aren't on the list above and want to be, please let 
-us know and we'll make sure you're here. Contributions from folks like you are 
+this Logstash plugin, and you aren't on the list above and want to be, please let
+us know and we'll make sure you're here. Contributions from folks like you are
 what make
 open source awesome.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This example will:
  * respect strings wrapped in double-quotes ("), and doesn't break those up
  * drop the results into `mapped_message`
  * add a value into `tags`, indicating that the fieldmap failed.
+
+Example configuration:
 ```ruby
 filter {
   fieldmap {

--- a/README.md
+++ b/README.md
@@ -1,8 +1,47 @@
-# Logstash Plugin
+# Logstash Filter fieldmap Plugin
 
-This is a plugin for [Logstash](https://github.com/elastic/logstash).
+This is basically a "advanced csv" plugin for [Logstash](https://github.com/elastic/logstash). The column delimiter can be any regex expression.
 
 It is fully free and fully open source. The license is Apache 2.0, meaning you are pretty much free to use it however you want in whatever way.
+
+## Examples
+
+You can see several examples in the test file (`./spec/filters/fieldmap_spec.rb`).
+
+This example will:
+ * split up the `message` into components separated by 1 or 2 whitespaces.
+ * respect strings wrapped in double-quotes ("), and doesn't break those up
+ * drop the results into `mapped_message`
+ * add a value into `tags`, indicating that the fieldmap failed.
+```ruby
+filter {
+  fieldmap {
+    src_field => 'message'
+    dst_field => 'mapped_message'
+    regex => '[[:blank]]{1,2}'
+    text_qualifier => '"'
+    keys => ['timestamp', 'log']
+  }
+}
+```
+
+Given the input of:
+```ruby
+{
+  'message' => '"05/19/2016 00:00:01"  "this is a super important log message"''
+}
+```
+
+It will output
+```ruby
+{
+  'message' => '"05/19/2016 00:00:01"  "this is a super important log message"''
+  'mapped_message' => {
+    'timestamp' => '05/19/2016 00:00:01'
+    'log' => 'this is a super important log message'
+  }
+}
+```
 
 ## Documentation
 

--- a/lib/logstash/filters/fieldmap.rb
+++ b/lib/logstash/filters/fieldmap.rb
@@ -37,7 +37,7 @@ class LogStash::Filters::FieldMap < LogStash::Filters::Base
   # Regex to split src_field by
   config :regex, :validate => :string, :default => '[[:space:]]'
 
-  # Regroup things that were unwantedly split by the regex
+  # Regroup things that were unwantedly split by the regex. This value can not be whitespace(s).
   config :text_qualifier, :validate => :string, :default => false
 
   # List of keys to use in the dst map
@@ -45,6 +45,8 @@ class LogStash::Filters::FieldMap < LogStash::Filters::Base
 
   # Append value to the tag field when the mapping failed
   config :map_failure, :validate => :string, :default => "_fieldmapfailed"
+  config :invalid_text_qualifier_failure, :validate => :string, :default => "_fieldmap_invalid_text_qualifier"
+  config :unmatched_text_qualifier_failure, :validate => :string, :default => "_fieldmap_unmatched_text_qualifier"
 
   public
   def register
@@ -62,20 +64,31 @@ class LogStash::Filters::FieldMap < LogStash::Filters::Base
       @logger.debug? and @logger.debug("split_src is: ", :split_src => split_src)
 
       if @text_qualifier
+        # protecting ourselves against bad things that could happen
+        if @text_qualifier.strip.length == 0
+            add_tag(event, @invalid_text_qualifier_failure)
+        end
+
         split_src_new_idx = split_src_orig_idx = 0
         qualifier_start_idx = -1
         split_src.map do |val|
 
-          val = val.strip   # this will cause problems if the text_qualifier is a space character
+          val = val.strip
 
           # Handle the case where we're in a qualified string
-          if val.start_with? @text_qualifier
-            qualifier_start_idx = split_src_orig_idx
-          elsif val.end_with? @text_qualifier
+          if val.end_with? @text_qualifier
+
+            # We caught an string "ending with" a quote before it starts with one. ruh roh.
+            if qualifier_start_idx < 0
+              add_tag(event, @unmatched_text_qualifier_failure)
+            end
+
             # TODO make this put in whatever it found to split on... not just a space
             val = split_src[qualifier_start_idx..split_src_orig_idx].join(' ')
             val = val.tr(@text_qualifier, "") # strips off the qualifier marks
             qualifier_start_idx = -1
+          elsif val.start_with? @text_qualifier
+            qualifier_start_idx = split_src_orig_idx
           end
 
           # this is the "not in the middle of a qualified string" (a.k.a normal) case
@@ -88,9 +101,7 @@ class LogStash::Filters::FieldMap < LogStash::Filters::Base
 
           # Handle the case where there is no "end" to the qualified string
           if split_src_orig_idx >= split_src.length
-            event["tags"] ||= []
-            event["tags"] << @map_failure unless event["tags"].include?(@map_failure)
-            @logger.info? and @logger.info("Event failed field map")
+            add_tag(event, @unmatched_text_qualifier_failure)
           end
         end
 
@@ -119,13 +130,23 @@ class LogStash::Filters::FieldMap < LogStash::Filters::Base
         end
         filter_matched(event)
       else
-        event["tags"] ||= []
-        event["tags"] << @map_failure unless event["tags"].include?(@map_failure)
-        @logger.info? and @logger.info("Event failed field map")
+        add_tag(event, @map_failure)
       end
     end
 
   @logger.debug? and @logger.debug("Event now: ", :event => event)
 
   end # def filter
+
+  ##
+  ## Private methods below here
+  ##
+  private
+
+  def add_tag(event, tag)
+    event["tags"] ||= []
+    event["tags"] << tag unless event["tags"].include?(tag)
+    @logger.info? and @logger.info("Event failed field map: " + tag)
+  end
+
 end # class LogStash::Filters::Example

--- a/lib/logstash/filters/fieldmap.rb
+++ b/lib/logstash/filters/fieldmap.rb
@@ -4,10 +4,10 @@ require "logstash/namespace"
 
 # This filter will split the src_field on delimiter and then
 # create a map in the dst_field by pairing the elements of
-# the keys config item with the values from the split src 
+# the keys config item with the values from the split src
 # field.
 #
-# If the number of elements in the split src_field and the 
+# If the number of elements in the split src_field and the
 # supplied keys is not the same the event will receive a tag
 # and be sent along
 #
@@ -26,7 +26,7 @@ class LogStash::Filters::FieldMap < LogStash::Filters::Base
   # }
   #
   config_name "fieldmap"
-  
+
   # Field to use as source for map values
   config :src_field, :validate => :string, :default => "message"
 
@@ -37,14 +37,18 @@ class LogStash::Filters::FieldMap < LogStash::Filters::Base
   # Regex to split src_field by
   config :regex, :validate => :string, :default => '[[:space:]]'
 
+  # Regroup things that were unwantedly split by the regex
+  config :text_qualifier, :validate => :string, :default => false
+
   # List of keys to use in the dst map
   config :keys, :validate => :array, :required => true
-  
+
   # Append value to the tag field when the mapping failed
   config :map_failure, :validate => :string, :default => "_fieldmapfailed"
+
   public
   def register
-    # Add instance variables 
+    # Add instance variables
   end # def register
 
   public
@@ -56,10 +60,53 @@ class LogStash::Filters::FieldMap < LogStash::Filters::Base
       #  the key lenght, if not, explode
       split_src = event[@src_field].split(/#{@regex}/)
       @logger.debug? and @logger.debug("split_src is: ", :split_src => split_src)
+
+      if @text_qualifier
+        split_src_new_idx = split_src_orig_idx = 0
+        qualifier_start_idx = -1
+        split_src.map do |val|
+
+          val = val.strip   # this will cause problems if the text_qualifier is a space character
+
+          # Handle the case where we're in a qualified string
+          if val.start_with? @text_qualifier
+            qualifier_start_idx = split_src_orig_idx
+          elsif val.end_with? @text_qualifier
+            # TODO make this put in whatever it found to split on... not just a space
+            val = split_src[qualifier_start_idx..split_src_orig_idx].join(' ')
+            val = val.tr(@text_qualifier, "") # strips off the qualifier marks
+            qualifier_start_idx = -1
+          end
+
+          # this is the "not in the middle of a qualified string" (a.k.a normal) case
+          if qualifier_start_idx < 0
+            split_src[split_src_new_idx] = val
+            split_src_new_idx += 1
+          end
+
+          split_src_orig_idx += 1
+
+          # Handle the case where there is no "end" to the qualified string
+          if split_src_orig_idx >= split_src.length
+            event["tags"] ||= []
+            event["tags"] << @map_failure unless event["tags"].include?(@map_failure)
+            @logger.info? and @logger.info("Event failed field map")
+          end
+        end
+
+        # cleanup the extra from the end now
+        split_src_new_idx -= 1
+        split_src_orig_idx -= 1
+        while split_src_orig_idx > split_src_new_idx do
+          split_src.delete_at(split_src_orig_idx)
+          split_src_orig_idx -= 1
+        end
+      end
+
       if split_src.length == @keys.length
         event[@dst_field] = {}  #  don't need to save off the source data, already split into split_src
         idx = 0
-        split_src.map do |val| 
+        split_src.map do |val|
           val = val.strip
           if val.include?('{')
             begin
@@ -67,7 +114,7 @@ class LogStash::Filters::FieldMap < LogStash::Filters::Base
             rescue LogStash::Json::ParserError  # if its not valid json leave it alone
             end
           end
-          event[@dst_field][@keys[idx]] = val 
+          event[@dst_field][@keys[idx]] = val
           idx=idx+1
         end
         filter_matched(event)

--- a/logstash-filter-fieldmap.gemspec
+++ b/logstash-filter-fieldmap.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-fieldmap'
-  s.version         = '0.0.2'
+  s.version         = '0.0.3'
   s.licenses = ['Apache License (2.0)']
   s.summary = "This filter will split the src_field on delimiter and then create a map in the dst_field by pairing the elements of the keys config item with the values from the split src field"
   s.description = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/fieldmap_spec.rb
+++ b/spec/filters/fieldmap_spec.rb
@@ -44,7 +44,7 @@ describe LogStash::Filters::FieldMap do
     end
   end
 
-  describe "should error on field to value mismatch" do
+  describe "should fail on field to value mismatch" do
     let(:config) do <<-CONFIG
       filter {
         fieldmap {
@@ -99,6 +99,26 @@ describe LogStash::Filters::FieldMap do
       expect(subject['mapped_message']).to eq({'timestamp' => '2016-05-26 05:00:00PST this is more words', 'log' => 'jibberish', 'log2' => 'ron swanson'})
     end
   end
+
+  describe "should fail on field to unmatched ' mismatch" do
+    let(:config) do <<-CONFIG
+      filter {
+        fieldmap {
+          src_field => 'message'
+          dst_field => 'mapped_message'
+          text_qualifier => "'"
+          keys => ['timestamp', 'log']
+        }
+      }
+    CONFIG
+    end
+
+    sample("message" => "'2012-03-03 01:10:01' 'Do not 'touch that dial!'") do
+      expect(subject).to include("message")
+      expect(subject['tags']).to eq(["_fieldmap_unmatched_text_qualifier"])
+    end
+  end
+
 
 
 end

--- a/spec/filters/fieldmap_spec.rb
+++ b/spec/filters/fieldmap_spec.rb
@@ -43,4 +43,62 @@ describe LogStash::Filters::FieldMap do
       expect(subject['mapped_message']).to eq({'Greeting' => 'Hello', 'Target' => 'Haters'})
     end
   end
+
+  describe "should error on field to value mismatch" do
+    let(:config) do <<-CONFIG
+      filter {
+        fieldmap {
+          src_field => 'message'
+          dst_field => 'mapped_message'
+          keys => ['timestamp', 'log']
+        }
+      }
+    CONFIG
+    end
+
+    sample("message" => '"2016-05-26 05:00:00PST" jibberish') do
+      expect(subject).to include("message")
+      expect(subject['tags']).to eq(["_fieldmapfailed"])
+    end
+  end
+
+  describe "should successfully allow \" to quote strings" do
+    let(:config) do <<-CONFIG
+      filter {
+        fieldmap {
+          src_field => 'message'
+          dst_field => 'mapped_message'
+          text_qualifier => '"'
+          keys => ['timestamp', 'log']
+        }
+      }
+    CONFIG
+    end
+
+    sample("message" => '"2016-05-26 05:00:00PST" jibberish') do
+      expect(subject).to include("message")
+      expect(subject['mapped_message']).to eq({'timestamp' => '2016-05-26 05:00:00PST', 'log' => 'jibberish'})
+    end
+  end
+
+  describe "should successfully allow qualification on several strings" do
+    let(:config) do <<-CONFIG
+      filter {
+        fieldmap {
+          src_field => 'message'
+          dst_field => 'mapped_message'
+          text_qualifier => '"'
+          keys => ['timestamp', 'log', 'log2']
+        }
+      }
+    CONFIG
+    end
+
+    sample("message" => '"2016-05-26 05:00:00PST this is more words" jibberish "ron swanson"') do
+      expect(subject).to include("message")
+      expect(subject['mapped_message']).to eq({'timestamp' => '2016-05-26 05:00:00PST this is more words', 'log' => 'jibberish', 'log2' => 'ron swanson'})
+    end
+  end
+
+
 end


### PR DESCRIPTION
We have logs of the form:

```
"05/19/2016 00:00:01"  10.0.0.1 /page.aspx ...
```

Previously, this plugin would split timestamp up into:
- `"05/19/2016`
- `00:00:01"`

This version would parse it as:
- `05/19/2016 00:00:01`
